### PR TITLE
Support `label` and `hidden` for fields

### DIFF
--- a/dbt2looker/generator.py
+++ b/dbt2looker/generator.py
@@ -298,6 +298,10 @@ def lookml_measure(measure_name: str, column: models.DbtModelColumn, measure: mo
         m['value_format_name'] = measure.value_format_name.value
     if measure.group_label:
         m['group_label'] = measure.group_label
+    if measure.label:
+        m['label'] = measure.label
+    if measure.hidden:
+        m['hidden'] = measure.hidden.value
     return m
 
 

--- a/dbt2looker/models.py
+++ b/dbt2looker/models.py
@@ -72,6 +72,11 @@ class LookerValueFormatName(str, Enum):
     percent_4 = 'percent_4'
 
 
+class LookerHiddenType(str, Enum):
+    yes = 'yes'
+    no = 'no'
+
+
 class Dbt2LookerMeasure(BaseModel):
     type: LookerAggregateMeasures
     filters: Optional[List[Dict[str, str]]] = []
@@ -79,6 +84,8 @@ class Dbt2LookerMeasure(BaseModel):
     sql: Optional[str]
     value_format_name: Optional[LookerValueFormatName]
     group_label: Optional[str]
+    label: Optional[str]
+    hidden: Optional[LookerHiddenType]
 
     @validator('filters')
     def filters_are_singular_dicts(cls, v: List[Dict[str, str]]):


### PR DESCRIPTION
## Motivation
We would like to support `label` and `hidden` for fields as well.

## Reference
- https://docs.looker.com/reference/field-params/hidden
- https://docs.looker.com/reference/field-params/label-for-field