### PR TITLE
Fix map_adapter_type_to_looker when column_type is None

### DIFF
--- a/dbt2looker/generator.py
+++ b/dbt2looker/generator.py
@@ -196,9 +196,11 @@ def normalise_spark_types(column_type: str) -> str:
 
 
 def map_adapter_type_to_looker(adapter_type: models.SupportedDbtAdapters, column_type: str):
+    if column_type is None:
+        return None
     normalised_column_type = (normalise_spark_types(column_type) if adapter_type == models.SupportedDbtAdapters.spark.value else column_type).upper()
     looker_type = LOOKER_DTYPE_MAP[adapter_type].get(normalised_column_type)
-    if (column_type is not None) and (looker_type is None):
+    if looker_type is None:
         logging.warning(f'Column type {column_type} not supported for conversion from {adapter_type} to looker. No dimension will be created.')
     return looker_type
 


### PR DESCRIPTION
The purpose of this change is to fix the

    AttributeError: 'NoneType' object has no attribute 'upper' 

raised by `map_adapter_type_to_looker` when called with `column_type = None`.

    
