### PR TITLE
Add Databricks Support

### DIFF
--- a/dbt2looker/generator.py
+++ b/dbt2looker/generator.py
@@ -188,6 +188,16 @@ LOOKER_DTYPE_MAP = {
     }
 }
 
+# Databricks is built on the Spark connector and uses the same datatypes
+LOOKER_DTYPE_MAP['databricks'] = LOOKER_DTYPE_MAP['spark']
+
+
+spark_like_adapters = [
+    models.SupportedDbtAdapters.databricks.value,
+    models.SupportedDbtAdapters.spark.value
+]
+
+
 looker_date_time_types = ['datetime', 'timestamp']
 looker_date_types = ['date']
 looker_scalar_types = ['number', 'yesno', 'string']
@@ -208,7 +218,7 @@ def normalise_spark_types(column_type: str) -> str:
 
 
 def map_adapter_type_to_looker(adapter_type: models.SupportedDbtAdapters, column_type: str):
-    normalised_column_type = (normalise_spark_types(column_type) if adapter_type == models.SupportedDbtAdapters.spark.value else column_type).upper()
+    normalised_column_type = (normalise_spark_types(column_type) if adapter_type in spark_like_adapters else column_type).upper()
     looker_type = LOOKER_DTYPE_MAP[adapter_type].get(normalised_column_type)
     if (column_type is not None) and (looker_type is None):
         logging.warning(f'Column type {column_type} not supported for conversion from {adapter_type} to looker. No dimension will be created.')

--- a/dbt2looker/generator.py
+++ b/dbt2looker/generator.py
@@ -163,16 +163,28 @@ LOOKER_DTYPE_MAP = {
         'BYTE':        'number',
         'SHORT':       'number',
         'INTEGER':     'number',
+        'INT':         'number',
+        'TINYINT':     'number',
+        'SMALLINT':    'number',
+        'BIGINT':      'number',
         'LONG':        'number',
         'FLOAT':       'number',
         'DOUBLE':      'number',
+        'REAL':        'number',
         'DECIMAL':     'number',
+        'DEC':         'number',
+        'NUMERIC':     'number',
         'STRING':      'string',
         'VARCHAR':     'string',
         'CHAR':        'string',
+        'BINARY':      'string',
         'BOOLEAN':     'yesno',
         'TIMESTAMP':   'timestamp',
         'DATE':        'datetime',
+        # ARRAY not supported
+        # STRUCT not supported
+        # INTERVAL <timeframe> not supported
+        # MAP not supported
     }
 }
 

--- a/dbt2looker/models.py
+++ b/dbt2looker/models.py
@@ -19,6 +19,7 @@ class SupportedDbtAdapters(str, Enum):
     redshift = 'redshift'
     snowflake = 'snowflake'
     spark = 'spark'
+    databricks = 'databricks'
 
 
 # Lookml types


### PR DESCRIPTION
This adds support for the dbt-databricks adapter, which is a layer on top of the Spark adapter. We're already using a version of this in our own lookml workflow at Daily and it's been working well for us.