### PR TITLE
Add view prefix argument

### DIFF
--- a/dbt2looker/cli.py
+++ b/dbt2looker/cli.py
@@ -100,6 +100,11 @@ def run():
         help='DB Connection Name for generated model files',
         type=str,
     )
+    argparser.add_argument(
+        '--view-prefix',
+        help='Prefix to add to view names and filenames',
+        type=str,
+    )
     args = argparser.parse_args()
     logging.basicConfig(
         level=getattr(logging, args.log_level),
@@ -118,8 +123,9 @@ def run():
     adapter_type = parser.parse_adapter_type(raw_manifest)
 
     # Generate lookml views
+    view_prefix = args.view_prefix or ''
     lookml_views = [
-        generator.lookml_view_from_dbt_model(model, adapter_type)
+        generator.lookml_view_from_dbt_model(model, adapter_type, view_prefix)
         for model in typed_dbt_models
     ]
     pathlib.Path(os.path.join(args.output_dir, 'views')).mkdir(parents=True, exist_ok=True)

--- a/dbt2looker/generator.py
+++ b/dbt2looker/generator.py
@@ -308,10 +308,10 @@ def lookml_measure(measure_name: str, column: models.DbtModelColumn, measure: mo
     return m
 
 
-def lookml_view_from_dbt_model(model: models.DbtModel, adapter_type: models.SupportedDbtAdapters):
+def lookml_view_from_dbt_model(model: models.DbtModel, adapter_type: models.SupportedDbtAdapters, view_prefix: str = ''):
     lookml = {
         'view': {
-            'name': model.name,
+            'name': f'{view_prefix}{model.name}',
             'sql_table_name': model.relation_name,
             'dimension_groups': lookml_dimension_groups_from_model(model, adapter_type),
             'dimensions': lookml_dimensions_from_model(model, adapter_type),
@@ -325,7 +325,7 @@ def lookml_view_from_dbt_model(model: models.DbtModel, adapter_type: models.Supp
         len(lookml['view']['dimensions']),
     )
     contents = lkml.dump(lookml)
-    filename = f'{model.name}.view.lkml'
+    filename = f'{view_prefix}{model.name}.view.lkml'
     return models.LookViewFile(filename=filename, contents=contents)
 
 


### PR DESCRIPTION
This last change may or may not be useful outside of my company's usage but we ended up in a scenario where we started with default Looker-generated views, which prefixed the schema to view names and files, built a number of explores and dashboards on top of them, and then decided to move to generated views + refinements. We wanted to match the new dbt2looker generated view names and files with the previously existing views for simplicity and to keep us from having to edit all the explores we'd already created, so I made this change in our fork. Totally understand if it doesn't seem useful enough generally to merge back upstream but I thought it was worth submitting a PR anyway.