### PR TITLE
Add more supported datetime timeframes

### DIFF
--- a/dbt2looker/generator.py
+++ b/dbt2looker/generator.py
@@ -185,9 +185,13 @@ looker_timeframes = [
     'time',
     'date',
     'week',
+    'day_of_week',
     'month',
+    'month_name',
     'quarter',
+    'quarter_of_year',
     'year',
+    'week_of_year',
 ]
 
 
@@ -210,7 +214,7 @@ def lookml_date_time_dimension_group(column: models.DbtModelColumn, adapter_type
         'sql': column.meta.dimension.sql or f'${{TABLE}}.{column.name}',
         'description': column.meta.dimension.description or column.description,
         'datatype': map_adapter_type_to_looker(adapter_type, column.data_type),
-        'timeframes': ['raw', 'time', 'hour', 'date', 'week', 'month', 'quarter', 'year']
+        'timeframes': looker_timeframes
     }
 
 

--- a/example/lookml/views/pages.view.lkml
+++ b/example/lookml/views/pages.view.lkml
@@ -9,12 +9,15 @@ view: pages {
     timeframes: [
       raw,
       time,
-      hour,
       date,
       week,
+      day_of_week,
       month,
+      month_name,
       quarter,
+      quarter_of_year,
       year,
+      week_of_year,
     ]
   }
 


### PR DESCRIPTION
We often ran into situations where we needed to analyse measures for `weekdays` or specific quarter (e.g. `Q3`) or with a specific `month_name` which usually matches with your other service's data. In those cases, to escape updating all your datetime group dimensions with more supported timeframes in `datetime/timestamps` groups:

This PR adds more supported datetime timeframes so we can use them in filters in looks/dashboards.

Example of such measure is:

- `working_days_since_last_viewed_at`
