### PR TITLE
Add support for ephemeral models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Recent and upcoming changes to dbt2looker
 
+## Unreleased
+### Added
+- support ephemeral models (#57)
+
 ## 0.11.0
 ### Added
 - support label and hidden fields (#49)

--- a/dbt2looker/models.py
+++ b/dbt2looker/models.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Union, Dict, List, Optional
+from typing import Any, Union, Dict, List, Optional
 try:
     from typing import Literal
 except ImportError:
@@ -144,6 +144,7 @@ class DbtModelColumn(BaseModel):
 class DbtNode(BaseModel):
     unique_id: str
     resource_type: str
+    config: Dict[str, Any]
 
 
 class Dbt2LookerExploreJoin(BaseModel):

--- a/dbt2looker/parser.py
+++ b/dbt2looker/parser.py
@@ -31,21 +31,21 @@ def tags_match(query_tag: str, model: models.DbtModel) -> bool:
 
 def parse_models(raw_manifest: dict, tag=None) -> List[models.DbtModel]:
     manifest = models.DbtManifest(**raw_manifest)
-    all_models: List[models.DbtModel] = [
+    materialized_models: List[models.DbtModel] = [
         node
         for node in manifest.nodes.values()
-        if node.resource_type == 'model'
+        if node.resource_type == 'model' and node.config['materialized'] != 'ephemeral'
     ]
 
     # Empty model files have many missing parameters
-    for model in all_models:
+    for model in materialized_models:
         if not hasattr(model, 'name'):
             logging.error('Cannot parse model with id: "%s" - is the model file empty?', model.unique_id)
             raise SystemExit('Failed')
 
     if tag is None:
-        return all_models
-    return [model for model in all_models if tags_match(tag, model)]
+        return materialized_models
+    return [model for model in materialized_models if tags_match(tag, model)]
 
 
 def check_models_for_missing_column_types(dbt_typed_models: List[models.DbtModel]):


### PR DESCRIPTION
This PR fixes the `dbt2looker` tool such that ephemeral models do not break it (see issue #57).

It is inspired by earlier suggestions by @boludo00 and @mariana-s-fernandes , with minor modifications.