### PR TITLE
Warn about catalog manifest discrepancy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Recent and upcoming changes to dbt2looker
 
+## Unreleased
+### Added
+- support ephemeral models (#57)
+
 ## 0.11.0
 ### Added
 - support label and hidden fields (#49)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Recent and upcoming changes to dbt2looker
 ## Unreleased
 ### Added
 - support ephemeral models (#57)
+- warnings if there is a discrepancy between manifest and catalog (#5)
+- more descriptive error message when a column's data type can't be inferred due to not being in the catalog
 
 ### Changed
 - only non-ephemeral models _selected by tag logic_ are checked to ensure the model files are not empty (instead of all models) (#57)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Recent and upcoming changes to dbt2looker
 ### Added
 - support ephemeral models (#57)
 
+### Changed
+- only non-ephemeral models _selected by tag logic_ are checked to ensure the model files are not empty (instead of all models) (#57)
+
 ## 0.11.0
 ### Added
 - support label and hidden fields (#49)

--- a/dbt2looker/models.py
+++ b/dbt2looker/models.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Union, Dict, List, Optional
+from typing import Any, Union, Dict, List, Optional
 try:
     from typing import Literal
 except ImportError:
@@ -144,6 +144,7 @@ class DbtModelColumn(BaseModel):
 class DbtNode(BaseModel):
     unique_id: str
     resource_type: str
+    config: Dict[str, Any]
 
 
 class Dbt2LookerExploreJoin(BaseModel):

--- a/dbt2looker/parser.py
+++ b/dbt2looker/parser.py
@@ -31,21 +31,21 @@ def tags_match(query_tag: str, model: models.DbtModel) -> bool:
 
 def parse_models(raw_manifest: dict, tag=None) -> List[models.DbtModel]:
     manifest = models.DbtManifest(**raw_manifest)
-    all_models: List[models.DbtModel] = [
+    materialized_models: List[models.DbtModel] = [
         node
         for node in manifest.nodes.values()
-        if node.resource_type == 'model'
+        if node.resource_type == 'model' and node.config['materialized'] != 'ephemeral'
     ]
 
     # Empty model files have many missing parameters
-    for model in all_models:
+    for model in materialized_models:
         if not hasattr(model, 'name'):
             logging.error('Cannot parse model with id: "%s" - is the model file empty?', model.unique_id)
             raise SystemExit('Failed')
 
     if tag is None:
-        return all_models
-    return [model for model in all_models if tags_match(tag, model)]
+        return materialized_models
+    return [model for model in materialized_models if tags_match(tag, model)]
 
 
 def check_models_for_missing_column_types(dbt_typed_models: List[models.DbtModel]):

--- a/dbt2looker/parser.py
+++ b/dbt2looker/parser.py
@@ -37,15 +37,18 @@ def parse_models(raw_manifest: dict, tag=None) -> List[models.DbtModel]:
         if node.resource_type == 'model' and node.config['materialized'] != 'ephemeral'
     ]
 
+    if tag is None:
+        selected_models = materialized_models
+    else:
+        selected_models = [model for model in materialized_models if tags_match(tag, model)]
+
     # Empty model files have many missing parameters
-    for model in materialized_models:
+    for model in selected_models:
         if not hasattr(model, 'name'):
             logging.error('Cannot parse model with id: "%s" - is the model file empty?', model.unique_id)
             raise SystemExit('Failed')
 
-    if tag is None:
-        return materialized_models
-    return [model for model in materialized_models if tags_match(tag, model)]
+    return selected_models
 
 
 def check_models_for_missing_column_types(dbt_typed_models: List[models.DbtModel]):


### PR DESCRIPTION
N.B. I stacked this PR on top of #90 - it contains those changes as well as the relevant ones for this work.

EDIT: #90 was split in two - this is now a stack of three PRs. Confusingly, the order is #90 -> #92 -> #91 (this PR)

---

An issue related to discrepancies between the DBT manifest and the DBT catalog caused me trouble earlier this year, and [was mentioned by some others, too (DBT Slack)](https://getdbt.slack.com/archives/C01DPMVM2LU/p1669718217943839).

It isn't explicitly included in an open issue, but is fundamentally related to #5 . That issue is about columns in the catalog that are not in the manifest, whereas my problem was about columns in the manifest that are not in the catalog (i.e. incorrectly documented columns).

I have added some warnings for both situations.

If a column in the manifest is not in the catalog, no column data type can be inferred. An uninformative error is raised when its looker type is mapped (caused by attempting to run `None.upper()`) - I have instead added an informative Exception, which is raised at the point of data-type inference (instead of returning `None` for the type, which, as far as I can tell, will always lead to a later error).