### PR TITLE
Filter models on tags before checking empties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Recent and upcoming changes to dbt2looker
 
+## Unreleased
+### Added
+- support ephemeral models (#57)
+
 ## 0.11.0
 ### Added
 - support label and hidden fields (#49)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Recent and upcoming changes to dbt2looker
 ### Added
 - support ephemeral models (#57)
 
+### Changed
+- only non-ephemeral models _selected by tag logic_ are checked to ensure the model files are not empty (instead of all models) (#57)
+
 ## 0.11.0
 ### Added
 - support label and hidden fields (#49)

--- a/dbt2looker/models.py
+++ b/dbt2looker/models.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Union, Dict, List, Optional
+from typing import Any, Union, Dict, List, Optional
 try:
     from typing import Literal
 except ImportError:
@@ -144,6 +144,7 @@ class DbtModelColumn(BaseModel):
 class DbtNode(BaseModel):
     unique_id: str
     resource_type: str
+    config: Dict[str, Any]
 
 
 class Dbt2LookerExploreJoin(BaseModel):

--- a/dbt2looker/parser.py
+++ b/dbt2looker/parser.py
@@ -31,21 +31,21 @@ def tags_match(query_tag: str, model: models.DbtModel) -> bool:
 
 def parse_models(raw_manifest: dict, tag=None) -> List[models.DbtModel]:
     manifest = models.DbtManifest(**raw_manifest)
-    all_models: List[models.DbtModel] = [
+    materialized_models: List[models.DbtModel] = [
         node
         for node in manifest.nodes.values()
-        if node.resource_type == 'model'
+        if node.resource_type == 'model' and node.config['materialized'] != 'ephemeral'
     ]
 
     # Empty model files have many missing parameters
-    for model in all_models:
+    for model in materialized_models:
         if not hasattr(model, 'name'):
             logging.error('Cannot parse model with id: "%s" - is the model file empty?', model.unique_id)
             raise SystemExit('Failed')
 
     if tag is None:
-        return all_models
-    return [model for model in all_models if tags_match(tag, model)]
+        return materialized_models
+    return [model for model in materialized_models if tags_match(tag, model)]
 
 
 def check_models_for_missing_column_types(dbt_typed_models: List[models.DbtModel]):

--- a/dbt2looker/parser.py
+++ b/dbt2looker/parser.py
@@ -37,15 +37,18 @@ def parse_models(raw_manifest: dict, tag=None) -> List[models.DbtModel]:
         if node.resource_type == 'model' and node.config['materialized'] != 'ephemeral'
     ]
 
+    if tag is None:
+        selected_models = materialized_models
+    else:
+        selected_models = [model for model in materialized_models if tags_match(tag, model)]
+
     # Empty model files have many missing parameters
-    for model in materialized_models:
+    for model in selected_models:
         if not hasattr(model, 'name'):
             logging.error('Cannot parse model with id: "%s" - is the model file empty?', model.unique_id)
             raise SystemExit('Failed')
 
-    if tag is None:
-        return materialized_models
-    return [model for model in materialized_models if tags_match(tag, model)]
+    return selected_models
 
 
 def check_models_for_missing_column_types(dbt_typed_models: List[models.DbtModel]):


### PR DESCRIPTION
[See conversation](https://github.com/lightdash/dbt2looker/pull/90#discussion_r1479725202) on [Add support for ephemeral models](https://github.com/lightdash/dbt2looker/pull/90).

This separates out the changes that were made in the `parser.parse_models` function to the order in which tag-based filtering is done. The effect of these changes is to avoid checking models that aren't included by the tag selector (so e.g. placeholder model files that are empty but are not targeted by the tag selector won't cause the entire run to fail).

N.B. this branch is stacked on top of the previous branch, so it contains both sets of changes. It is reliant on the previous changes to make sense.