### PR TITLE
Migrate to Pydantic v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Recent and upcoming changes to dbt2looker
 
+## Unreleased
+### Added
+- support ephemeral models (#57)
+
 ## 0.11.0
 ### Added
 - support label and hidden fields (#49)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Recent and upcoming changes to dbt2looker
 ## Unreleased
 ### Added
 - support ephemeral models (#57)
+- warnings if there is a discrepancy between manifest and catalog (#5)
+- more descriptive error message when a column's data type can't be inferred due to not being in the catalog
 
 ### Changed
 - only non-ephemeral models _selected by tag logic_ are checked to ensure the model files are not empty (instead of all models) (#57)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Recent and upcoming changes to dbt2looker
 ### Added
 - support ephemeral models (#57)
 
+### Changed
+- only non-ephemeral models _selected by tag logic_ are checked to ensure the model files are not empty (instead of all models) (#57)
+
 ## 0.11.0
 ### Added
 - support label and hidden fields (#49)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Recent and upcoming changes to dbt2looker
 ### Changed
 - only non-ephemeral models _selected by tag logic_ are checked to ensure the model files are not empty (instead of all models) (#57)
 
+### Fixed
+- now supports `pydantic` v2 (#97)
+
 ## 0.11.0
 ### Added
 - support label and hidden fields (#49)

--- a/dbt2looker/models.py
+++ b/dbt2looker/models.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Union, Dict, List, Optional
+from typing import Any, Union, Dict, List, Optional
 try:
     from typing import Literal
 except ImportError:
@@ -144,6 +144,7 @@ class DbtModelColumn(BaseModel):
 class DbtNode(BaseModel):
     unique_id: str
     resource_type: str
+    config: Dict[str, Any]
 
 
 class Dbt2LookerExploreJoin(BaseModel):

--- a/dbt2looker/models.py
+++ b/dbt2looker/models.py
@@ -4,13 +4,14 @@ try:
     from typing import Literal
 except ImportError:
     from typing_extensions import Literal
-from pydantic import BaseModel, Field, PydanticValueError, validator
+from pydantic import BaseModel, Field, validator
 
 
 # dbt2looker utility types
-class UnsupportedDbtAdapterError(PydanticValueError):
-    code = 'unsupported_dbt_adapter'
-    msg_template = '{wrong_value} is not a supported dbt adapter'
+class UnsupportedDbtAdapterError(ValueError):
+    def __init__(self, wrong_value: str):
+        msg = f'{wrong_value} is not a supported dbt adapter'
+        super().__init__(msg)
 
 
 class SupportedDbtAdapters(str, Enum):
@@ -82,12 +83,12 @@ class LookerHiddenType(str, Enum):
 class Dbt2LookerMeasure(BaseModel):
     type: LookerMeasureType
     filters: Optional[List[Dict[str, str]]] = []
-    description: Optional[str]
-    sql: Optional[str]
-    value_format_name: Optional[LookerValueFormatName]
-    group_label: Optional[str]
-    label: Optional[str]
-    hidden: Optional[LookerHiddenType]
+    description: Optional[str] = None
+    sql: Optional[str] = None
+    value_format_name: Optional[LookerValueFormatName] = None
+    group_label: Optional[str] = None
+    label: Optional[str] = None
+    hidden: Optional[LookerHiddenType] = None
 
     @validator('filters')
     def filters_are_singular_dicts(cls, v: List[Dict[str, str]]):
@@ -100,10 +101,10 @@ class Dbt2LookerMeasure(BaseModel):
 
 class Dbt2LookerDimension(BaseModel):
     enabled: Optional[bool] = True
-    name: Optional[str]
-    sql: Optional[str]
-    description: Optional[str]
-    value_format_name: Optional[LookerValueFormatName]
+    name: Optional[str] = None
+    sql: Optional[str] = None
+    description: Optional[str] = None
+    value_format_name: Optional[LookerValueFormatName] = None
 
 
 class Dbt2LookerMeta(BaseModel):
@@ -137,7 +138,7 @@ class DbtModelColumnMeta(Dbt2LookerMeta):
 class DbtModelColumn(BaseModel):
     name: str
     description: str
-    data_type: Optional[str]
+    data_type: Optional[str] = None
     meta: DbtModelColumnMeta
 
 
@@ -201,13 +202,13 @@ class DbtCatalogNodeMetadata(BaseModel):
     type: str
     db_schema: str = Field(..., alias='schema')
     name: str
-    comment: Optional[str]
-    owner: Optional[str]
+    comment: Optional[str] = None
+    owner: Optional[str] = None
 
 
 class DbtCatalogNodeColumn(BaseModel):
     type: str
-    comment: Optional[str]
+    comment: Optional[str] = None
     index: int
     name: str
 

--- a/dbt2looker/parser.py
+++ b/dbt2looker/parser.py
@@ -31,21 +31,21 @@ def tags_match(query_tag: str, model: models.DbtModel) -> bool:
 
 def parse_models(raw_manifest: dict, tag=None) -> List[models.DbtModel]:
     manifest = models.DbtManifest(**raw_manifest)
-    all_models: List[models.DbtModel] = [
+    materialized_models: List[models.DbtModel] = [
         node
         for node in manifest.nodes.values()
-        if node.resource_type == 'model'
+        if node.resource_type == 'model' and node.config['materialized'] != 'ephemeral'
     ]
 
     # Empty model files have many missing parameters
-    for model in all_models:
+    for model in materialized_models:
         if not hasattr(model, 'name'):
             logging.error('Cannot parse model with id: "%s" - is the model file empty?', model.unique_id)
             raise SystemExit('Failed')
 
     if tag is None:
-        return all_models
-    return [model for model in all_models if tags_match(tag, model)]
+        return materialized_models
+    return [model for model in materialized_models if tags_match(tag, model)]
 
 
 def check_models_for_missing_column_types(dbt_typed_models: List[models.DbtModel]):

--- a/dbt2looker/parser.py
+++ b/dbt2looker/parser.py
@@ -37,15 +37,18 @@ def parse_models(raw_manifest: dict, tag=None) -> List[models.DbtModel]:
         if node.resource_type == 'model' and node.config['materialized'] != 'ephemeral'
     ]
 
+    if tag is None:
+        selected_models = materialized_models
+    else:
+        selected_models = [model for model in materialized_models if tags_match(tag, model)]
+
     # Empty model files have many missing parameters
-    for model in materialized_models:
+    for model in selected_models:
         if not hasattr(model, 'name'):
             logging.error('Cannot parse model with id: "%s" - is the model file empty?', model.unique_id)
             raise SystemExit('Failed')
 
-    if tag is None:
-        return materialized_models
-    return [model for model in materialized_models if tags_match(tag, model)]
+    return selected_models
 
 
 def check_models_for_missing_column_types(dbt_typed_models: List[models.DbtModel]):


### PR DESCRIPTION
This will fix #97 - I encountered the same problems when I needed to upgrade to Pydantic v2 in my DBT project.

Two changes are required to effect the migration:

First, I have removed the import of `PydanticValueError`, which no longer exists. I don't think any special functionality was provided by this import, and my sense is that the `Pydantic...` errors are for their internal use (the errors codes are now hardwired into `ErrorCodes`, a `Literal`, and don't seem to encourage custom use as previously in `dbt2looker`. Therefore the custom error is now derived from `ValueError` and should produce the same output message if a specific adaptor is not supported.

Secondly, `Optional` fields are [now handled differently](https://docs.pydantic.dev/latest/migration/#required-optional-and-nullable-fields). I have given a default value of `None` to all the ones that had no default value, which should be behaviour-preserving (value doesn't have to be supplied and doesn't have a 'special' default value).

I tested it on my own DBT project to verify that nothing unexpected happens.

### IMPORTANT NOTE

Naturally I need to keep my own fork of the project operational. Therefore this PR is built on top of my stack of open PRs. It is the fourth in the stack. [**Reviewers should review only the most recent commit.**](https://github.com/lightdash/dbt2looker/pull/98/commits/51dbdfb66ea5760bae07acce0efe7a3698a0276c)